### PR TITLE
Update token list to add Fraterim token to list

### DIFF
--- a/src/tokens/harmony-mainnet.json
+++ b/src/tokens/harmony-mainnet.json
@@ -118,5 +118,13 @@
     "name": "ONEMILLION",
     "decimals": 18,
     "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/1MIL.png"
+  },
+  {
+    "chainId": 1666600000,
+    "address": "0x5305d2fcfc9981c4518c498194df493968d1d822",
+    "symbol": "FRATE",
+    "name": "Fraterium",
+    "decimals": 18,
+    "logoURI": "https://drive.google.com/file/d/1EB9tdbsdTVadc_SmiMdtTsuAshkwtrjj/view?usp=sharing"
   }
 ]


### PR DESCRIPTION
Fraterium token is created to serve as a unit of value accounting within the framework of the relationship in the Frateria people's association and a tool for conducting mutual settlements between united citizens, with the consent of the parties involved in these operations.
It is a HardCap coin with only 3391 coins created.
Frateria itself is planning to serve as a didactic center to entities willing to benefit from the blockchain and DeFi technologies.